### PR TITLE
New puppet aliases default

### DIFF
--- a/aliases.d/puppet
+++ b/aliases.d/puppet
@@ -2,5 +2,13 @@
 
 source ~/.bash/functions
 
-register_alias pupclean 'for i in $(find ./ -name '*.pp'); do puppet-clean -a -b -e -l -m -o -r -t2 -v -w $i > $i.new ; mv $i $i.bak ; mv $i.new $i; done'
+function pupclean() {
+  for i in $(find ./ -name '*.pp');
+  do
+    puppet-clean -a -b -e -l -m -o -r -t2 -v -w $i > $i.new
+    mv $i $i.bak
+    mv $i.new $i
+  done
+}
+
 register_alias puplint "find ./ -name '*.pp' -exec puppet-lint --no-80chars-check --with-filename --with-context {} \;"


### PR DESCRIPTION
These are two default aliases for puppet-lint and puppet-cleaner tool.

They parse a directory and search for all .pp file the apply the specified tool on them.
