### PR TITLE
Simulate pbcopy and pbpaste on Linux

### DIFF
--- a/aliases.d/defaults
+++ b/aliases.d/defaults
@@ -5,6 +5,8 @@ source ~/.bash/functions
 case $( uname -s ) in
   Linux)
     register_alias ls "ls -a --color"
+    register_alias pbcopy "xsel --clipboard --input"
+    register_alias pbpaste "xsel --clipboard --output"
     ;;
   Darwin)
     register_alias ls "ls -aG"


### PR DESCRIPTION
This requires the xsel package to be installed but works well